### PR TITLE
fix: validate duplicate course creation

### DIFF
--- a/Assignment 12/services/course_service.py
+++ b/Assignment 12/services/course_service.py
@@ -22,10 +22,16 @@ class CourseService:
         with open(self.file_path, 'w') as f:
             json.dump(self.courses, f, indent=2)
 
+    def _get_course_by_id(self, course_id: int):
+        return next((c for c in self.courses if c["course_id"] == course_id), None)
+
     def create_course(self, course_id: int, title: str, description: str, instructor_id: int = 1):
-        if not title:
+        if not title or not title.strip():
             raise ValueError("Course title is required")
-        
+
+        if self._get_course_by_id(course_id):
+            raise ValueError(f"Course with ID {course_id} already exists.")
+
         course = {
             "course_id": course_id,
             "title": title,
@@ -40,20 +46,24 @@ class CourseService:
         return self.courses
 
     def update_course(self, course_id: int, title: str = None, description: str = None):
-        course = next((c for c in self.courses if c["course_id"] == course_id), None)
+        course = self._get_course_by_id(course_id)
         if not course:
             raise ValueError(f"Course with ID {course_id} not found")
-        
-        if title: course["title"] = title
+
+        if title is not None:
+            if not title.strip():
+                raise ValueError("Course title is required")
+            course["title"] = title
+
         if description: course["description"] = description
         self._save_courses()
         return course
 
     def delete_course(self, course_id: int):
-        course = next((c for c in self.courses if c["course_id"] == course_id), None)
+        course = self._get_course_by_id(course_id)
         if not course:
             raise ValueError(f"Course with ID {course_id} not found")
-        
+
         self.courses.remove(course)
         self._save_courses()
         return f"Course {course_id} deleted successfully"

--- a/Assignment 12/tests/test_course_validation.py
+++ b/Assignment 12/tests/test_course_validation.py
@@ -1,0 +1,47 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from services.course_service import CourseService
+
+
+def test_create_course_rejects_duplicate_course_id(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    service = CourseService()
+
+    first_course = service.create_course(101, "Python Basics", "Introductory Python course")
+
+    with pytest.raises(ValueError, match="Course with ID 101 already exists"):
+        service.create_course(101, "Python Basics Duplicate", "Duplicate course")
+
+    assert service.get_all_courses() == [first_course]
+
+    with open("data/courses.json") as courses_file:
+        persisted_courses = json.load(courses_file)
+
+    assert persisted_courses == [first_course]
+
+
+def test_create_course_rejects_blank_title(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    service = CourseService()
+
+    with pytest.raises(ValueError, match="Course title is required"):
+        service.create_course(102, "   ", "Invalid title")
+
+    assert service.get_all_courses() == []
+
+
+def test_update_course_rejects_blank_title(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    service = CourseService()
+    course = service.create_course(103, "Web Development", "Build web applications")
+
+    with pytest.raises(ValueError, match="Course title is required"):
+        service.update_course(103, title=" ")
+
+    assert service.get_all_courses() == [course]


### PR DESCRIPTION
## Summary

Implemented a small course service validation improvement identified during repository analysis.

## Problem

Course creation allowed multiple courses with the same `course_id`, unlike student creation which already rejects duplicate student IDs. Course titles were also only checked for truthiness, so whitespace-only titles could be created or applied during updates.

## Solution

- Added a reusable course lookup helper in `CourseService`.
- Rejected duplicate `course_id` values before persisting new courses.
- Added focused service tests covering duplicate IDs, blank creation titles, blank update titles, and persistence behavior.

## Testing

python -m pytest 'Assignment 12/tests'` passed.
<img width="1872" height="284" alt="image" src="https://github.com/user-attachments/assets/d9761c05-e582-4bd1-b98f-ab6fbacee217" />

## Impact

This improves correctness and data integrity for the course API/service layer by preventing ambiguous duplicate course records and invalid blank course titles from being persisted.