### PR TITLE
docs: fix setup formatting and doc links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,3 +45,26 @@ We follow the Contributor Covenant Code of Conduct. We expect all contributors t
 ```bash
 git clone https://github.com/YOUR_USERNAME/the-it-code-academy.git
 cd the-it-code-academy
+cd "Assignment 12"
+pip install -r requirements.txt
+python -m pytest tests/ -v
+```
+
+---
+
+## Coding Standards
+
+- Keep changes focused and easy to review.
+- Use clear names for files, classes, functions, and variables.
+- Add or update tests when you change behavior.
+- Run the relevant tests before opening a Pull Request.
+
+---
+
+## How to Contribute
+
+1. Choose an open issue or propose a small improvement.
+2. Create a branch with a descriptive name.
+3. Make the smallest change that solves the issue.
+4. Verify the change locally.
+5. Open a Pull Request and describe what changed.

--- a/README.md
+++ b/README.md
@@ -14,19 +14,18 @@ The goal is to reduce barriers to digital education by providing an **affordable
 
 ### Quick Local Setup
 
-
-# Clone the repository
 ```bash
+# Clone the repository
 git clone https://github.com/keo-codes/the-it-code-academy.git
 cd the-it-code-academy
-```
 
-# Backend Setup
+# Backend setup
 cd "Assignment 12"
 pip install -r requirements.txt
 
 # Run tests to verify everything works
 python -m pytest tests/ -v
+```
 
 ### Features Open for Contribution
 
@@ -68,11 +67,11 @@ Contains **C4 diagrams** and system structure.
 - [System Requirements Document (SRD)](./SYSTEM-REQUIREMENTS.md)  
 
 ### Design & Testing
-- [Use Case Specifications](./USE-CASES.md)  
+- [Use Case Specifications](./USE-CASE-SPECIFICATIONS.md)
 - [Test Cases](./TEST-CASES.md)  
 
 ### Reflection
-- [Final Reflection](./REFLECTION.md)  
+- [Final Reflection](Assignment%2015/REFLECTION.md)
 
 ---
 
@@ -86,9 +85,9 @@ THE-IT-CODE-ACADEMY
 ├── ARCHITECTURE.md
 ├── STAKEHOLDER-ANALYSIS.md
 ├── SYSTEM-REQUIREMENTS.md
-├── USE-CASES.md
+├── USE-CASE-SPECIFICATIONS.md
 ├── TEST-CASES.md
-├── REFLECTION.md
+├── Assignment 15/REFLECTION.md
 │
 └── C4-Diagrams
     ├── system-context-diagram.png


### PR DESCRIPTION
## Summary

Closes #47.

- fixes the README Quick Local Setup block so all setup commands render inside one bash code block
- updates README links and the repository tree for files that actually exist in the repo
- completes the truncated CONTRIBUTING setup snippet and adds short coding/contribution guidance

## Validation

- `git diff --check`
- verified README relative links resolve to existing files
- Claude Code CLI review: PASS

AI assistance disclosure: prepared with GPT-5 Codex and manually validated before submission.