### PR TITLE
fix: repair enrollment lookup route

### DIFF
--- a/Assignment 12/main.py
+++ b/Assignment 12/main.py
@@ -33,13 +33,11 @@ def root():
 # New endpoint to get a student's enrollments
 @app.get("/api/students/{student_id}/enrollments")
 def get_student_enrollments(student_id: int):
-    return enrollment_service.get_student_courses(student_id)
-   def get_student_courses(self, student_id):
+    try:
+        return enrollment_service.get_student_courses(student_id)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
 
-    return {
-        "student_id": student_id,
-        "courses": self.enrollments.get(student_id, [])
-    } 
 @app.get("/api/students")
 def get_all_students():
     return student_service.get_all_students()
@@ -106,7 +104,7 @@ def enroll_student(student_id: int, course_id: int):
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-print("🚀 THE IT CODE ACADEMY API IS READY!")
+print("THE IT CODE ACADEMY API IS READY!")
 print("Visit: http://localhost:8000/docs")
 
 if __name__ == "__main__":

--- a/Assignment 12/services/enrollment_service.py
+++ b/Assignment 12/services/enrollment_service.py
@@ -32,3 +32,15 @@ class EnrollmentService:
             "message": f"Student {student_id} successfully enrolled in course {course_id}",
             "student": student
         }
+
+    def get_student_courses(self, student_id: int):
+        """Return the current course IDs for a student."""
+        student = self.student_service.get_student_by_id(student_id)
+
+        if not student:
+            raise ValueError(f"Student with ID {student_id} not found")
+
+        return {
+            "student_id": student_id,
+            "courses": student.get("enrolled_courses", []),
+        }

--- a/Assignment 12/tests/test_enrollment_api.py
+++ b/Assignment 12/tests/test_enrollment_api.py
@@ -1,0 +1,51 @@
+import importlib
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+
+ASSIGNMENT_DIR = Path(__file__).resolve().parents[1]
+if str(ASSIGNMENT_DIR) not in sys.path:
+    sys.path.insert(0, str(ASSIGNMENT_DIR))
+
+
+def _load_main_module():
+    sys.modules.pop("main", None)
+    return importlib.import_module("main")
+
+
+def test_get_student_enrollments_returns_saved_courses(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    main = _load_main_module()
+    client = TestClient(main.app)
+
+    create_response = client.post(
+        "/api/students",
+        params={
+            "student_id": 1,
+            "first_name": "Ada",
+            "last_name": "Lovelace",
+            "email": "ada@example.com",
+        },
+    )
+    assert create_response.status_code == 200
+
+    enroll_response = client.post("/api/students/1/enroll", params={"course_id": 200})
+    assert enroll_response.status_code == 200
+
+    response = client.get("/api/students/1/enrollments")
+
+    assert response.status_code == 200
+    assert response.json() == {"student_id": 1, "courses": [200]}
+
+
+def test_get_student_enrollments_returns_404_for_missing_student(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    main = _load_main_module()
+    client = TestClient(main.app)
+
+    response = client.get("/api/students/999/enrollments")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Student with ID 999 not found"}


### PR DESCRIPTION
## Summary

- fix the `/api/students/{student_id}/enrollments` route so it calls `EnrollmentService.get_student_courses`
- move the missing helper into `EnrollmentService` and return a 404 when the student does not exist
- add focused FastAPI tests for the successful enrollment lookup and missing-student path
- replace the emoji startup print with ASCII so importing `main.py` works in Windows console environments

## Validation

- `git diff --check HEAD~1..HEAD`
- `python -c "compile(Path('Assignment 12/main.py').read_text(encoding='utf-8'), 'Assignment 12/main.py', 'exec')"`
- `uv run --with fastapi --with "uvicorn[standard]" --with pydantic --with pytest --with pytest-asyncio pytest tests/test_enrollment_api.py -q` from `Assignment 12` -> `2 passed, 1 warning`
